### PR TITLE
v0.0.5: Add option to not verify remote vault certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ into their own mount. This could be achieved with a configuration like:
                 - %{environment}
                 - secret
 
+## SSL
+
+    To use a vault server with SSL, but without verifying the remote certificate, use:
+
+    :vault:
+        # ...
+        :ssl_no_verify: true
+
+
 ## TODO
 
 This is very much alpha, some improvements:

--- a/hiera-vault.gemspec
+++ b/hiera-vault.gemspec
@@ -3,7 +3,7 @@ require 'rubygems/package_task'
 
 spec = Gem::Specification.new do |gem|
     gem.name = "hiera-vault"
-    gem.version = "0.0.4"
+    gem.version = "0.0.5"
     gem.license = "Apache-2.0"
     gem.summary = "Module for using vault as a hiera backend"
     gem.email = "jonathan.sokolowski@gmail.com"

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -13,6 +13,7 @@ class Hiera
 
         begin
           @vault = Vault::Client.new(address: @config[:addr], token: @config[:token])
+          @vault.ssl_verify = false if @config[:ssl_no_verify] == true
           fail if @vault.sys.seal_status.sealed?
           Hiera.debug("[hiera-vault] Client configured to connect to #{@vault.address}")
         rescue Exception => e


### PR DESCRIPTION
Here's a quick patch to allow this to work without verifying remote vault SSL certs.
