### PR TITLE
Support setting ssl cipher versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ SSL can be configured with the following config variables:
         :ssl_ca_cert: /path/to/ca.crt
         :ssl_ca_path: /path/to/ca/
         :ssl_verify: false
-
+        :ssl_ciphers: "MY:SSL:CIPHER:CONFIG"
 
 ## TODO
 

--- a/hiera-vault.gemspec
+++ b/hiera-vault.gemspec
@@ -3,7 +3,7 @@ require 'rubygems/package_task'
 
 spec = Gem::Specification.new do |gem|
     gem.name = "hiera-vault"
-    gem.version = "0.1.1"
+    gem.version = "0.1.2"
     gem.license = "Apache-2.0"
     gem.summary = "Module for using vault as a hiera backend"
     gem.email = "jonathan.sokolowski@gmail.com"

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -20,6 +20,7 @@ class Hiera
             config.ssl_verify = @config[:ssl_verify]
             config.ssl_ca_cert = @config[:ssl_ca_cert] if config.respond_to? :ssl_ca_cert
             config.ssl_ca_path = @config[:ssl_ca_path] if config.respond_to? :ssl_ca_path
+            config.ssl_ciphers = @config[:ssl_ciphers] if config.respond_to? :ssl_ciphers
           end
 
           fail if @vault.sys.seal_status.sealed?


### PR DESCRIPTION
The Hashicorp vault gem has started enforcing specific SSL ciphers. Their default config breaks with puppetserver/jRuby - here's a patch to support overriding it.

Any chance you could push a new version to ruby-gems?
