### PR TITLE
Add ability to retrieve a single, default field

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ via the same environment variables read by
 
 ## Lookups
 
+### Hash - default
+
 Since vault stores data in Key/Value pairs, this naturally lends itself to
 returning a Hash on lookup.
 For example:
@@ -34,6 +36,22 @@ For example:
 The hiera lookup for `foo` will return a Hash:
 
     {"value"=>"bar","other"=>"baz"}
+
+### Single Value - optional
+
+If you use just a single field to store data, eg. "value" - you can request that just this is returned as a string, instead of a hash.
+
+To do this, set:
+
+    :vault:
+        :default_field: value
+
+For example:
+
+    vault write secret/foo value=bar other=baz
+
+The hiera lookup for `foo` will return just "bar" as a string.
+
 
 ## Backends and Mounts
 
@@ -61,17 +79,6 @@ into their own mount. This could be achieved with a configuration like:
             :generic:
                 - %{environment}
                 - secret
-
-## Default field
-
-Vault has the ability to store many fields inside an object. By default, we return all of them as a hash.
-
-If you just use a single field to store data, eg. 'value' - you can request that just this is returned as a string, instead of a hash.
-
-To do this, set:
-
-    :vault:
-        :default_field: value
 
 
 ## SSL

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ into their own mount. This could be achieved with a configuration like:
                 - %{environment}
                 - secret
 
+## Default field
+
+Vault has the ability to store many fields inside an object. By default, we return all of them as a hash.
+
+If you just use a single field to store data, eg. 'value' - you can request that just this is returned as a string, instead of a hash.
+
+To do this, set:
+
+    :vault:
+        :default_field: value
+
+
 ## SSL
 
 SSL can be configured with the following config variables:

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -61,8 +61,13 @@ class Hiera
           return nil if secret.nil?
 
           Hiera.debug("[hiera-vault] Read secret: #{key}")
-          # Turn secret's hash keys into strings
-          data = secret.data.inject({}) { |h, (k, v)| h[k.to_s] = v; h }
+          if @config[:default_field]
+            # Return just our default_field
+            data = secret.data[@config[:default_field].to_sym]
+          else
+            # Turn secret's hash keys into strings
+            data = secret.data.inject({}) { |h, (k, v)| h[k.to_s] = v; h }
+          end
 
           return Backend.parse_answer(data, scope)
       end


### PR DESCRIPTION
We use just a single field per vault object, and we have to convert data back from a hash inside our puppet code.

This patch allows us to use vault / yaml interchangeably in hiera lookups, as no post-processing to extract the field is necessary.

Default is the original behaviour.
