### PR TITLE
Do not overwrite config values if empty.

### DIFF
--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -14,10 +14,10 @@ class Hiera
         begin
           @vault = Vault::Client.new
           @vault.configure do |config|
-            config.address = @config[:addr]
-            config.token = @config[:token]
-            config.ssl_pem_file = @config[:ssl_pem_file]
-            config.ssl_verify = @config[:ssl_verify]
+            config.address = @config[:addr] if @config[:addr]
+            config.token = @config[:token] if @config[:token]
+            config.ssl_pem_file = @config[:ssl_pem_file] if @config[:ssl_pem_file]
+            config.ssl_verify = @config[:ssl_verify] if @config[:ssl_verify]
             config.ssl_ca_cert = @config[:ssl_ca_cert] if config.respond_to? :ssl_ca_cert
             config.ssl_ca_path = @config[:ssl_ca_path] if config.respond_to? :ssl_ca_path
             config.ssl_ciphers = @config[:ssl_ciphers] if config.respond_to? :ssl_ciphers


### PR DESCRIPTION
Fixes #5.
Config defaults (i.e. env vars and token file) were being ignored.
