### PR TITLE
Flagged

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ To accomplish this, the vault backend can be configured with the following:
 To make this work, this gem comes with three specific functions named `hiera_vault`,
 `hiera_vault_array`, and `hiera_vault_hash`, which should be used instead of the
 corresponding normal hiera lookup functions, to get data out of vault.
-Without the `:flag_default` option, lookups will be done in vault first, and then in
+Without the `:flag_default` option, or when set to 'vault_first', lookups will be done in vault first, and then in
 the other backends. If `:flag_default` is set to 'vault_only', the `hiera_vault*` functions
 will only use the vault backend.
 With `:override_behavior` set to 'flag', the vault backend will skip looking in vault when

--- a/README.md
+++ b/README.md
@@ -168,6 +168,28 @@ will only use the vault backend.
 With `:override_behavior` set to 'flag', the vault backend will skip looking in vault when
 lookups are done with the normal hiera lookup functions.
 
+When using any of the specific functions, a puppet run will fail with an error stating:
+
+    [hiera-vault] Cannot skip, because vault is unavailable and vault must be read, while override_behavior is 'flag'
+
+
+### Auto-generating and writing secrets with `hiera_vault()` - `:default_field` required
+This works only when `:default_field` has been configured and `:override_behavior: 'flag'` is in
+effect.
+
+When using the following call with `hiera_vault` in your puppet code, a password will be generated
+automatically and stored at the `override` or highest level hierarchy path, in case no `override`
+has been specified:
+
+    $some_password = hiera_vault('some_key', {'generate' => 20}, 'some_override_path')
+
+In case the `key` does not exist at any path in the mounts/hierarchy lists, a password string will
+be generated with the given length, using alphanumeric characters only. Then it will be stored in
+vault at the first path that was examined. As such it is highly recommended to use an override path
+to ensure using the same value on different nodes, in case that's desired.
+In some cases it might be desired to have a different password on each node. In such a case,
+`$::fqdn` can be used as the override parameter.
+
 
 ## SSL
 

--- a/README.md
+++ b/README.md
@@ -134,13 +134,39 @@ into their own mount. This could be achieved with a configuration like:
                 - secret
 
 
-### Use global `:hierarchy` - optional
+## Use global `:hierarchy` - optional
 By default, only the list of mounts is traversed as described above. When having configured:
 
     :vault:
         :use_hierarchy: 'yes'
 
 the `:hierarchy` source paths from the hiera configuration are used on top of each mount.
+
+
+## Flagged usage - optional
+By default all hiera lookups are done through all backends.
+In case of vault, it might be desirable to skip vault in normal
+hiera lookups, while you already know up front that the key is not present
+in vault.
+Lookups in vault are relatively expensive, since for each key a connection to vault
+is made as many times as there are mounts and even a multiple of that when using the
+`:hierarchy` list.
+Additionally it might also be desirable to lookup keys in vault only.
+
+To accomplish this, the vault backend can be configured with the following:
+
+    :vault:
+        :override_behavior: 'flag'
+        :flag_default: 'vault_only'
+
+To make this work, this gem comes with three specific functions named `hiera_vault`,
+`hiera_vault_array`, and `hiera_vault_hash`, which should be used instead of the
+corresponding normal hiera lookup functions, to get data out of vault.
+Without the `:flag_default` option, lookups will be done in vault first, and then in
+the other backends. If `:flag_default` is set to 'vault_only', the `hiera_vault*` functions
+will only use the vault backend.
+With `:override_behavior` set to 'flag', the vault backend will skip looking in vault when
+lookups are done with the normal hiera lookup functions.
 
 
 ## SSL

--- a/hiera-vault.gemspec
+++ b/hiera-vault.gemspec
@@ -3,7 +3,7 @@ require 'rubygems/package_task'
 
 spec = Gem::Specification.new do |gem|
     gem.name = "hiera-vault"
-    gem.version = "0.1.6.pre1"
+    gem.version = "0.1.5.pre1"
     gem.license = "Apache-2.0"
     gem.summary = "Module for using vault as a hiera backend"
     gem.email = "jonathan.sokolowski@gmail.com"

--- a/hiera-vault.gemspec
+++ b/hiera-vault.gemspec
@@ -3,7 +3,7 @@ require 'rubygems/package_task'
 
 spec = Gem::Specification.new do |gem|
     gem.name = "hiera-vault"
-    gem.version = "0.1.5.pre1"
+    gem.version = "0.1.6.pre1"
     gem.license = "Apache-2.0"
     gem.summary = "Module for using vault as a hiera backend"
     gem.email = "jonathan.sokolowski@gmail.com"

--- a/hiera-vault.gemspec
+++ b/hiera-vault.gemspec
@@ -3,11 +3,11 @@ require 'rubygems/package_task'
 
 spec = Gem::Specification.new do |gem|
     gem.name = "hiera-vault"
-    gem.version = "0.1.5.pre1"
+    gem.version = "0.1.4"
     gem.license = "Apache-2.0"
     gem.summary = "Module for using vault as a hiera backend"
     gem.email = "jonathan.sokolowski@gmail.com"
-    gem.authors = ["Jonathan Sokolowski", "Arnoud Witt"]
+    gem.author = "Jonathan Sokolowski"
     gem.homepage = "http://github.com/jsok/hiera-vault"
     gem.description = "Hiera backend for looking up secrets stored in Vault"
     gem.require_path = "lib"

--- a/hiera-vault.gemspec
+++ b/hiera-vault.gemspec
@@ -3,11 +3,11 @@ require 'rubygems/package_task'
 
 spec = Gem::Specification.new do |gem|
     gem.name = "hiera-vault"
-    gem.version = "0.1.4"
+    gem.version = "0.1.5.pre1"
     gem.license = "Apache-2.0"
     gem.summary = "Module for using vault as a hiera backend"
     gem.email = "jonathan.sokolowski@gmail.com"
-    gem.author = "Jonathan Sokolowski"
+    gem.authors = ["Jonathan Sokolowski", "Arnoud Witt"]
     gem.homepage = "http://github.com/jsok/hiera-vault"
     gem.description = "Hiera backend for looking up secrets stored in Vault"
     gem.require_path = "lib"

--- a/hiera-vault.gemspec
+++ b/hiera-vault.gemspec
@@ -3,7 +3,7 @@ require 'rubygems/package_task'
 
 spec = Gem::Specification.new do |gem|
     gem.name = "hiera-vault"
-    gem.version = "0.1.6.pre2"
+    gem.version = "0.1.6.pre1"
     gem.license = "Apache-2.0"
     gem.summary = "Module for using vault as a hiera backend"
     gem.email = "jonathan.sokolowski@gmail.com"

--- a/hiera-vault.gemspec
+++ b/hiera-vault.gemspec
@@ -3,7 +3,7 @@ require 'rubygems/package_task'
 
 spec = Gem::Specification.new do |gem|
     gem.name = "hiera-vault"
-    gem.version = "0.1.6.pre1"
+    gem.version = "0.1.6.pre2"
     gem.license = "Apache-2.0"
     gem.summary = "Module for using vault as a hiera backend"
     gem.email = "jonathan.sokolowski@gmail.com"

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -67,7 +67,6 @@ class Hiera
           read_vault = false
           genpw = false
           otp = nil
-          flag_default_used = false
 
           if @config[:override_behavior] == 'flag'
             if order_override.kind_of? Hash
@@ -75,7 +74,7 @@ class Hiera
                 if ['vault_default','vault_first','vault_only'].include?(order_override['flag'])
                   read_vault = true
                   if order_override['flag'] == 'vault_default'
-                    flag_default_used = true
+                    # since variables are passed by reference, the caller will know afterwards, which flag was actually used
                     order_override['flag'] = @config[:flag_default]
                   end
                   if order_override.has_key?('generate')
@@ -169,10 +168,6 @@ class Hiera
           if answer.nil? and not otp.nil?
             answer = otp
           end
-          if flag_default_used
-            # the caller needs to know the flag value that was used, so here it is encapsulated in the answer
-            answer = {'flag_used' => @config[:flag_default], 'answer' => answer }
-          }
           return answer
         rescue Exception => e
           raise Exception, "#{e.message} in #{e.backtrace[0]}"

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -208,10 +208,8 @@ class Hiera
       def lookup_generic(key, scope)
           begin
             secret = @vault.logical.read(key)
-          rescue Vault::HTTPConnectionError
-            Hiera.debug("[hiera-vault] Could not connect to read secret: #{key}")
-          rescue Vault::HTTPError => e
-            Hiera.warn("[hiera-vault] Could not read secret #{key}: #{e.errors.join("\n").rstrip}")
+          rescue Exception => e
+            raise Exception, "[hiera-vault] Could not read secret #{key}, #{e.class}: #{e.errors.join("\n").rstrip}"
           end
 
           return nil if secret.nil?

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -67,6 +67,7 @@ class Hiera
           read_vault = false
           genpw = false
           otp = nil
+          flag_default_used = false
 
           if @config[:override_behavior] == 'flag'
             if order_override.kind_of? Hash
@@ -74,6 +75,7 @@ class Hiera
                 if ['vault_default','vault_first','vault_only'].include?(order_override['flag'])
                   read_vault = true
                   if order_override['flag'] == 'vault_default'
+                    flag_default_used = true
                     order_override['flag'] = @config[:flag_default]
                   end
                   if order_override.has_key?('generate')
@@ -167,6 +169,10 @@ class Hiera
           if answer.nil? and not otp.nil?
             answer = otp
           end
+          if flag_default_used
+            # the caller needs to know the flag value that was used, so here it is encapsulated in the answer
+            answer = {'flag_used' => @config[:flag_default], 'answer' => answer }
+          }
           return answer
         rescue Exception => e
           raise Exception, "#{e.message} in #{e.backtrace[0]}"

--- a/lib/hiera_vault.rb
+++ b/lib/hiera_vault.rb
@@ -41,10 +41,6 @@ module HieraVault
       override['resolution_type'] = resolution_type
 
       new_answer = HieraPuppet.lookup(key, nil, scope, override, :priority)
-      if override['flag'] == 'vault_default'
-        override['flag'] = new_answer['flag_used']
-        new_answer = new_answer['answer']
-      end
       if new_answer == otp
         # this means that vault_backend could not find anything, so it returned the value of vault_otp
         new_answer = nil

--- a/lib/hiera_vault.rb
+++ b/lib/hiera_vault.rb
@@ -1,121 +1,121 @@
 require 'hiera_puppet'
-require 'hiera/backend/vault_backend'
 
 module HieraVault
+
   module_function
-
   def lookup(key, default, scope, override, resolution_type)
-    @hiera_config ||= HieraPuppet.hiera_config
-    if not (@hiera_config.has_key?(:backends) and @hiera_config[:backends].include?('vault') and @hiera_config.has_key?(:vault))
-      raise(Puppet::ParseError, "hiera_vault: vault backend not configured in hiera config")
-    end
-
-    @vault_config ||= @hiera_config[:vault]
-    if not (@vault_config.has_key?(:override_behavior) and @vault_config[:override_behavior] == 'flag')
-      raise(Puppet::ParseError, "hiera_vault: :override_behavior needs to be set to 'flag' in hiera config")
-    end
-
-    flag_default = 'vault'
-    if @vault_config.has_key?(:flag_default)
-      flag_default = @vault_config[:flag_default]
-      if not ['vault','vault_only'].include?(flag_default)
-        raise(Puppet::ParseError, "hiera_vault: invalid value '#{flag_default}' for :flag_default in hiera config, one of 'vault', 'vault_only' expected")
+    begin
+      flag_default = 'vault_default'
+      override ||= {'flag' => flag_default}
+      case override.class.to_s
+      when 'String'
+        override = {'flag' => flag_default, 'override' => override}
+      when 'Hash'
+        if not override.has_key?('flag')
+          override['flag'] = flag_default
+        end
+      else
+        raise(Puppet::ParseError, "hiera_vault: invalid 'override' parameter supplied: '#{override}':#{override.class}")
       end
-    end
 
-    override ||= {'flag' => flag_default}
-    case override.class.to_s
-    when 'String'
-      override = {'flag' => flag_default, 'override' => override}
-    when 'Hash'
-      if not override.has_key?('flag')
-        override['flag'] = flag_default
-      end
-    else
-      raise(Puppet::ParseError, "hiera_vault: invalid 'override' parameter supplied: '#{override}':#{override.class}")
-    end
-
-    if resolution_type == :priority
-      if default.kind_of? Hash
-        if default.has_key?('generate')
-          if @vault_config[:default_field]
+      if resolution_type == :priority
+        if default.kind_of? Hash
+          if default.has_key?('generate')
             override['generate'] = default['generate'].to_i
             default = nil
           end
         end
       end
-    end
 
-    # this part is needed, since the 'default' parameter is not available in backends
-    @vault_backend ||= Hiera::Backend::Vault_backend.new
-    hiera_scope = Hiera::Scope.new(scope)
-    new_answer = @vault_backend.lookup(key, hiera_scope, override, resolution_type)
-    if new_answer.nil?
-      answer = new_answer
-    else
+      r = rand(2147483647).to_s
+      otp = "vault_otp_#{r}"
       case resolution_type
       when :array
-        raise Exception, "hiera_vault: after vault_backend.lookup: type mismatch: expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String
-        answer ||= []
-        answer << new_answer
+        otp = [otp]
       when :hash
-        raise Exception, "hiera_vault: after vault_backend.lookup: type mismatch: expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
-        answer ||= {}
-        answer = Hiera::Backend.merge_answer(new_answer,answer)
+        otp = {'otp' => otp}
+      end
+      override['vault_otp'] = otp
+
+      # this is for vault_backend so that it will use the actual resolution type internally
+      override['resolution_type'] = resolution_type
+
+      new_answer = HieraPuppet.lookup(key, nil, scope, override, :priority)
+      if new_answer == otp
+        # this means that vault_backend could not find anything, so it returned the value of vault_otp
+        new_answer = nil
+      end
+
+      if new_answer.nil?
+        answer = nil
       else
-        answer = new_answer
-      end
-    end
-
-    if override['flag'] == 'vault_only'
-      if not (default.nil? or default.empty?)
-        answer = Hiera::Backend.resolve_answer(answer, resolution_type) unless answer.nil?
-        answer = Hiera::Backend.parse_string(default, hiera_scope) if answer.nil? and default.is_a?(String)
-        answer = default if answer.nil?
-      end
-      if answer.nil?
-        raise(Puppet::ParseError, "hiera_vault: Could not find data item #{key} in vault, while vault_only was requested, and empty default supplied")
-      end
-      return answer
-    end
-
-    if answer.nil? or resolution_type != :priority
-      # continue with normal hiera lookup, while vault_backend will skip automatically
-      if override.has_key?('override')
-        override = override['override']
-      else
-        override = nil
-      end
-
-      begin
-        new_answer = HieraPuppet.lookup(key, nil, scope, override, resolution_type)
-      rescue Puppet::ParseError
-        if answer.nil?
-          if default.nil? or default.empty?
-            raise(Puppet::ParseError, "Could not find data item #{key} in vault and in any Hiera data file and no or empty default supplied")
-          end
-          answer = Hiera::Backend.parse_string(default, hiera_scope) if default.is_a?(String)
-          answer = default if answer.nil?
-          return answer
+        case resolution_type
+        when :array
+          raise Puppet::ParseError, "hiera_vault: after vault_backend.lookup: type mismatch: expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String
+          answer ||= []
+          answer << new_answer
+        when :hash
+          raise Puppet::ParseError, "hiera_vault: after vault_backend.lookup: type mismatch: expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
+          answer ||= {}
+          answer = Hiera::Backend.merge_answer(new_answer,answer)
+        else
+          answer = new_answer
         end
       end
-    end
-    if not new_answer.nil?
-      case resolution_type
-      when :array
-        raise Exception, "hiera_vault: after normal Hiera lookup: type mismatch: expected Array and got #{new_answer.class}" unless new_answer.nil? or new_answer.kind_of? Array or new_answer.kind_of? String
-        answer ||= []
-        answer << new_answer
-      when :hash
-        raise Exception, "hiera_vault: after normal Hiera lookup: type mismatch: expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
-        answer ||= {}
-        answer = Hiera::Backend.merge_answer(new_answer,answer)
-      else
-        answer = new_answer
+
+      hiera_scope = Hiera::Scope.new(scope)
+      if override['flag'] == 'vault_only'
+        if not (default.nil? or default.empty?)
+          answer = Hiera::Backend.resolve_answer(answer, resolution_type) unless answer.nil?
+          answer = Hiera::Backend.parse_string(default, hiera_scope) if answer.nil? and default.is_a?(String)
+          answer = default if answer.nil?
+        end
+        if answer.nil?
+          raise(Puppet::ParseError, "hiera_vault: Could not find data item #{key} in vault, while vault_only was requested, and empty default supplied")
+        end
+        return answer
       end
+
+      if answer.nil? or resolution_type != :priority
+        # continue with normal hiera lookup, while vault_backend will skip automatically
+        if override.has_key?('override')
+          override = override['override']
+        else
+          override = nil
+        end
+
+        begin
+          new_answer = HieraPuppet.lookup(key, nil, scope, override, resolution_type)
+        rescue Puppet::ParseError
+          if answer.nil?
+            if default.nil? or default.empty?
+              raise(Puppet::ParseError, "Could not find data item #{key} in vault and in any Hiera data file and no or empty default supplied")
+            end
+            answer = Hiera::Backend.parse_string(default, hiera_scope) if default.is_a?(String)
+            answer = default if answer.nil?
+            return answer
+          end
+        end
+      end
+      if not new_answer.nil?
+        case resolution_type
+        when :array
+          raise Puppet::ParseError, "hiera_vault: after normal Hiera lookup: type mismatch: expected Array and got #{new_answer.class}" unless new_answer.nil? or new_answer.kind_of? Array or new_answer.kind_of? String
+          answer ||= []
+          answer << new_answer
+        when :hash
+          raise Puppet::ParseError, "hiera_vault: after normal Hiera lookup: type mismatch: expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
+          answer ||= {}
+          answer = Hiera::Backend.merge_answer(new_answer,answer)
+        else
+          answer = new_answer
+        end
+      end
+      answer = Hiera::Backend.resolve_answer(answer, resolution_type)
+      return answer
+    rescue Exception => e
+      raise(Puppet::ParseError, "#{e.message} in #{e.backtrace[0]}")
     end
-    answer = Hiera::Backend.resolve_answer(answer, resolution_type)
-    return answer
   end
 
 end

--- a/lib/hiera_vault.rb
+++ b/lib/hiera_vault.rb
@@ -41,6 +41,10 @@ module HieraVault
       override['resolution_type'] = resolution_type
 
       new_answer = HieraPuppet.lookup(key, nil, scope, override, :priority)
+      if override['flag'] == 'vault_default'
+        override['flag'] = new_answer['flag_used']
+        new_answer = new_answer['answer']
+      end
       if new_answer == otp
         # this means that vault_backend could not find anything, so it returned the value of vault_otp
         new_answer = nil

--- a/lib/hiera_vault.rb
+++ b/lib/hiera_vault.rb
@@ -1,0 +1,102 @@
+require 'hiera_puppet'
+require 'hiera/backend/vault_backend'
+
+module HieraVault
+  module_function
+
+  def lookup(key, default, scope, override, resolution_type)
+    @hiera_config ||= HieraPuppet.hiera_config
+    if not (@hiera_config.has_key?(:backends) and @hiera_config[:backends].include?('vault') and @hiera_config.has_key?(:vault))
+      raise(Puppet::ParseError, "hiera_vault: vault backend not configured in hiera config")
+    end
+
+    @vault_config ||= @hiera_config[:vault]
+    if not (@vault_config.has_key?(:override_behavior) and @vault_config[:override_behavior] == 'flag')
+      raise(Puppet::ParseError, "hiera_vault: :override_behavior needs to be set to 'flag' in hiera config")
+    end
+
+    flag_default = 'vault'
+    if @vault_config.has_key?(:flag_default)
+      flag_default = @vault_config[:flag_default]
+      if not ['vault','vault_only'].include?(flag_default)
+        raise(Puppet::ParseError, "hiera_vault: invalid value '#{flag_default}' for :flag_default in hiera config, one of 'vault', 'vault_only' expected")
+      end
+    end
+
+    override ||= {'flag' => flag_default}
+    case override.class.to_s
+    when 'String'
+      override = {'flag' => flag_default, 'override' => override}
+    when 'Hash'
+      if not override.has_key?('flag')
+        override['flag'] = flag_default
+      end
+    else
+      raise(Puppet::ParseError, "hiera_vault: invalid 'override' parameter supplied: '#{override}':#{override.class}")
+    end
+    # this part is needed, since the 'default' parameter is not available in backends
+    @vault_backend ||= Hiera::Backend::Vault_backend.new
+    hiera_scope = Hiera::Scope.new(scope)
+    new_answer = @vault_backend.lookup(key, hiera_scope, override, resolution_type)
+    if new_answer.nil?
+      answer = new_answer
+    else
+      case resolution_type
+      when :array
+        raise Exception, "hiera_vault: after vault_backend.lookup: type mismatch: expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String
+        answer ||= []
+        answer << new_answer
+      when :hash
+        raise Exception, "hiera_vault: after vault_backend.lookup: type mismatch: expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
+        answer ||= {}
+        answer = Hiera::Backend.merge_answer(new_answer,answer)
+      else
+        answer = new_answer
+      end
+    end
+
+    if override['flag'] == 'vault_only'
+      if not (default.nil? or default.empty?)
+        answer = Hiera::Backend.resolve_answer(answer, resolution_type) unless answer.nil?
+        answer = Hiera::Backend.parse_string(default, hiera_scope) if answer.nil? and default.is_a?(String)
+        answer = default if answer.nil?
+      end
+      if answer.nil?
+        raise(Puppet::ParseError, "hiera_vault: Could not find data item #{key} in vault, while vault_only was requested, and empty default supplied")
+      end
+      return answer
+    end
+
+    if answer.nil? or resolution_type != :priority
+      # continue with normal hiera lookup, while vault_backend will skip automatically
+      if override.has_key?('override')
+        override = override['override']
+      else
+        override = nil
+      end
+
+      begin
+        new_answer = HieraPuppet.lookup(key, nil, scope, override, resolution_type)
+      rescue Puppet::ParseError
+        answer = Hiera::Backend.parse_string(default, hiera_scope) if default.is_a?(String)
+        answer = default if answer.nil?
+        return answer
+      end
+    end
+    case resolution_type
+    when :array
+      raise Exception, "hiera_vault: after normal Hiera lookup: type mismatch: expected Array and got #{new_answer.class}" unless new_answer.nil? or new_answer.kind_of? Array or new_answer.kind_of? String
+      answer ||= []
+      answer << new_answer
+    when :hash
+      raise Exception, "hiera_vault: after normal Hiera lookup: type mismatch: expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
+      answer ||= {}
+      answer = Hiera::Backend.merge_answer(new_answer,answer)
+    else
+      answer = new_answer
+    end
+    answer = Hiera::Backend.resolve_answer(answer, resolution_type)
+    return answer
+  end
+end
+

--- a/lib/puppet/parser/functions/hiera_vault.rb
+++ b/lib/puppet/parser/functions/hiera_vault.rb
@@ -1,0 +1,67 @@
+require 'hiera_puppet'
+require 'hiera/backend/vault_backend'
+
+module Puppet::Parser::Functions
+  newfunction(:hiera_vault, :type => :rvalue, :arity => -2, :doc => "Performs a
+  hiera lookup, first and optionally only in the 'vault' backend.
+
+  The behavior depends on the 'override' parameter.
+
+  NOTICE: For this function to work properly, set :override_behavior: 'flag' in the
+  :vault: config part in the hiera config.
+  ") do |*args|
+    @hiera_config ||= HieraPuppet.hiera_config
+    if not (@hiera_config.has_key?(:backends) and @hiera_config[:backends].include?('vault') and @hiera_config.has_key?(:vault))
+      raise(Puppet::ParseError, "hiera_vault: vault backend not configured in hiera config")
+    end
+
+    @vault_config ||= @hiera_config[:vault]
+    if not (@vault_config.has_key?(:override_behavior) and @vault_config[:override_behavior] == 'flag')
+      raise(Puppet::ParseError, "hiera_vault :vault::override_behavior needs to be set to 'flag' in hiera config")
+    end
+
+    flag_default = 'vault'
+    if @vault_config.has_key?(:flag_default)
+      flag_default = @vault_config[:flag_default]
+      if not ['vault','vault_only'].include?(flag_default)
+        raise(Puppet::ParseError, "hiera_vault: invalid value '#{flag_default}' for :flag_default in hiera config, one of 'vault', 'vault_only' expected")
+      end
+    end
+
+    key, default, override = HieraPuppet.parse_args(args)
+    override ||= {'flag' => flag_default}
+    case override.class.to_s
+    when 'String'
+      override = {'flag' => flag_default, 'override' => override}
+    when 'Hash'
+      if not override.has_key?('flag')
+        override['flag'] = flag_default
+      end
+    else
+      raise(Puppet::ParseError, "hiera_vault: invalid 'override' parameter supplied: '#{override}':#{override.class}")
+    end
+    # this part is needed, since the 'default' parameter is not available in backends
+    @vault_backend ||= Hiera::Backend::Vault_backend.new
+    scope = Hiera::Scope.new(self)
+    answer = @vault_backend.lookup(key, scope, override, :priority)
+    if override['flag'] == 'vault_only'
+      if not (default.nil? or default.empty?)
+        answer = Hiera::Backend.parse_string(default, scope) if answer.nil? and default.is_a?(String)
+        answer = default if answer.nil?
+      end
+      if answer.nil?
+        raise(Puppet::ParseError, "hiera_vault: Could not find data item #{key} in vault, while vault_only was requested, and empty default supplied")
+      end
+      return answer
+    end
+    if answer.nil?
+      if override.has_key?('override')
+        override = override['override']
+      else
+        override = nil
+      end
+      answer = function_hiera([key, default, override])
+    end
+    return answer
+  end
+end

--- a/lib/puppet/parser/functions/hiera_vault.rb
+++ b/lib/puppet/parser/functions/hiera_vault.rb
@@ -1,5 +1,5 @@
 require 'hiera_puppet'
-require 'hiera/backend/vault_backend'
+require 'hiera_vault'
 
 module Puppet::Parser::Functions
   newfunction(:hiera_vault, :type => :rvalue, :arity => -2, :doc => "Performs a
@@ -10,58 +10,8 @@ module Puppet::Parser::Functions
   NOTICE: For this function to work properly, set :override_behavior: 'flag' in the
   :vault: config part in the hiera config.
   ") do |*args|
-    @hiera_config ||= HieraPuppet.hiera_config
-    if not (@hiera_config.has_key?(:backends) and @hiera_config[:backends].include?('vault') and @hiera_config.has_key?(:vault))
-      raise(Puppet::ParseError, "hiera_vault: vault backend not configured in hiera config")
-    end
-
-    @vault_config ||= @hiera_config[:vault]
-    if not (@vault_config.has_key?(:override_behavior) and @vault_config[:override_behavior] == 'flag')
-      raise(Puppet::ParseError, "hiera_vault :vault::override_behavior needs to be set to 'flag' in hiera config")
-    end
-
-    flag_default = 'vault'
-    if @vault_config.has_key?(:flag_default)
-      flag_default = @vault_config[:flag_default]
-      if not ['vault','vault_only'].include?(flag_default)
-        raise(Puppet::ParseError, "hiera_vault: invalid value '#{flag_default}' for :flag_default in hiera config, one of 'vault', 'vault_only' expected")
-      end
-    end
-
     key, default, override = HieraPuppet.parse_args(args)
-    override ||= {'flag' => flag_default}
-    case override.class.to_s
-    when 'String'
-      override = {'flag' => flag_default, 'override' => override}
-    when 'Hash'
-      if not override.has_key?('flag')
-        override['flag'] = flag_default
-      end
-    else
-      raise(Puppet::ParseError, "hiera_vault: invalid 'override' parameter supplied: '#{override}':#{override.class}")
-    end
-    # this part is needed, since the 'default' parameter is not available in backends
-    @vault_backend ||= Hiera::Backend::Vault_backend.new
-    scope = Hiera::Scope.new(self)
-    answer = @vault_backend.lookup(key, scope, override, :priority)
-    if override['flag'] == 'vault_only'
-      if not (default.nil? or default.empty?)
-        answer = Hiera::Backend.parse_string(default, scope) if answer.nil? and default.is_a?(String)
-        answer = default if answer.nil?
-      end
-      if answer.nil?
-        raise(Puppet::ParseError, "hiera_vault: Could not find data item #{key} in vault, while vault_only was requested, and empty default supplied")
-      end
-      return answer
-    end
-    if answer.nil?
-      if override.has_key?('override')
-        override = override['override']
-      else
-        override = nil
-      end
-      answer = function_hiera([key, default, override])
-    end
-    return answer
+    HieraVault.lookup(key, default, self, override, :priority)
   end
 end
+

--- a/lib/puppet/parser/functions/hiera_vault_array.rb
+++ b/lib/puppet/parser/functions/hiera_vault_array.rb
@@ -1,0 +1,83 @@
+require 'hiera_puppet'
+require 'hiera/backend/vault_backend'
+
+module Puppet::Parser::Functions
+  newfunction(:hiera_vault, :type => :rvalue, :arity => -2, :doc => "Performs a
+  hiera_array lookup, first and optionally only in the 'vault' backend.
+
+  The behavior depends on the 'override' parameter.
+
+  NOTICE: For this function to work properly, set :override_behavior: 'flag' in the
+  :vault: config part in the hiera config.
+  ") do |*args|
+    @hiera_config ||= HieraPuppet.hiera_config
+    if not (@hiera_config.has_key?(:backends) and @hiera_config[:backends].include?('vault') and @hiera_config.has_key?(:vault))
+      raise(Puppet::ParseError, "hiera_vault: vault backend not configured in hiera config")
+    end
+
+    @vault_config ||= @hiera_config[:vault]
+    if not (@vault_config.has_key?(:override_behavior) and @vault_config[:override_behavior] == 'flag')
+      raise(Puppet::ParseError, "hiera_vault :vault::override_behavior needs to be set to 'flag' in hiera config")
+    end
+
+    flag_default = 'vault'
+    if @vault_config.has_key?(:flag_default)
+      flag_default = @vault_config[:flag_default]
+      if not ['vault','vault_only'].include?(flag_default)
+        raise(Puppet::ParseError, "hiera_vault: invalid value '#{flag_default}' for :flag_default in hiera config, one of 'vault', 'vault_only' expected")
+      end
+    end
+
+    key, default, override = HieraPuppet.parse_args(args)
+    override ||= {'flag' => flag_default}
+    case override.class.to_s
+    when 'String'
+      override = {'flag' => flag_default, 'override' => override}
+    when 'Hash'
+      if not override.has_key?('override')
+        raise(Puppet::ParseError, "hiera_vault: missing 'override' key in override hash: '#{override}':#{override.class}")
+      end
+      if not override.has_key?('flag')
+        override['flag'] = flag_default
+      end
+    else
+      raise(Puppet::ParseError, "hiera_vault: invalid 'override' parameter supplied: '#{override}':#{override.class}")
+    end
+    # this part is needed, since the 'default' parameter is not available in backends
+    @vault_backend ||= Hiera::Backend::Vault_backend.new
+    scope = Hiera::Scope.new(self)
+    new_answer = @vault_backend.lookup(key, scope, override, :array)
+    raise Exception, "Hiera type mismatch: expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String
+    answer ||= []
+    answer << new_answer
+    if override['flag'] == 'vault_only'
+      if not (default.nil? or default.empty?)
+        answer = Hiera::Backend.resolve_answer(answer, :array) unless answer.nil?
+        answer = Hiera::Backend.parse_string(default, scope) if answer.nil? and default.is_a?(String)
+        answer = default if answer.nil?
+      end
+      if answer.nil?
+        raise(Puppet::ParseError, "hiera_vault: Could not find data item #{key} in vault, while vault_only was requested, and empty default supplied")
+      end
+      return answer
+    end
+    # continue with other backends using normal hiera_array call, vault backend will be skipped automatically
+    if override.has_key?('override')
+      override = override['override']
+    else
+      override = nil
+    end
+    begin
+      new_answer = HieraPuppet.lookup(key, nil, scope, override, :array)
+    rescue Puppet::ParseError
+      answer = Hiera::Backend.parse_string(default, scope) if default.is_a?(String)
+      answer = default if answer.nil?
+      return answer
+    end
+    raise Exception, "Hiera type mismatch: expected Array and got #{new_answer.class}" unless new_answer.nil? or new_answer.kind_of? Array or new_answer.kind_of? String
+    answer ||= []
+    answer << new_answer
+    answer = Hiera::Backend.resolve_answer(answer, :array)
+    return answer
+  end
+end

--- a/lib/puppet/parser/functions/hiera_vault_hash.rb
+++ b/lib/puppet/parser/functions/hiera_vault_hash.rb
@@ -2,8 +2,8 @@ require 'hiera_puppet'
 require 'hiera_vault'
 
 module Puppet::Parser::Functions
-  newfunction(:hiera_vault_array, :type => :rvalue, :arity => -2, :doc => "Performs a
-  hiera_array lookup, first and optionally only in the 'vault' backend.
+  newfunction(:hiera_vault_hash, :type => :rvalue, :arity => -2, :doc => "Performs a
+  hiera_hash lookup, first and optionally only in the 'vault' backend.
 
   The behavior depends on the 'override' parameter.
 
@@ -11,7 +11,7 @@ module Puppet::Parser::Functions
   :vault: config part in the hiera config.
   ") do |*args|
     key, default, override = HieraPuppet.parse_args(args)
-    HieraVault.lookup(key, default, self, override, :array)
+    HieraVault.lookup(key, default, self, override, :hash)
   end
 end
 


### PR DESCRIPTION
This changeset (use_hierarchy branch #9 merged into it) adds the feature to read from vault, only when using custom `hiera_vault`, `hiera_vault_array`, and `hiera_vault_hash` functions in the puppet code.
Normal `hiera*` function calls will cause the `vault` backend to skip reading from vault.

Why? Because always reading from vault is pretty heavy and easily can exhaust the number of source ports on the puppet master. Found this when doing test runs in a relatively small environment.

Additional features:
- Flag `hiera_vault*` calls to tell it to look in vault only. This can even be the default behavior.
- Generate and write secrets in case they are not found in vault, by using a special value for the second argument (the fallback default) of the `hiera_vault*` functions.
- Better handling/renewing connections to vault in case vault has been temporarily unavailable.
- Handle empty fallback default values as invalid when using `hiera_vault*` functions. Actually a side effect of making it possible to specify a third parameter without a valid fallback default.

More info in the README and the code.
