### PR TITLE
Extra option to prioritize environment variables

### DIFF
--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -27,9 +27,16 @@ class Hiera
 
         begin
           @vault = Vault::Client.new
+          if @config[:prioritize_env]
+            addr = ENV['VAULT_ADDR'] || @config[:addr]
+            token = ENV['VAULT_TOKEN'] || @config[:token]
+          else
+            addr = @config[:addr] || ENV['VAULT_ADDR']
+            token = @config[:token] || ENV['VAULT_TOKEN']
+          end
           @vault.configure do |config|
-            config.address = @config[:addr] if @config[:addr]
-            config.token = @config[:token] if @config[:token]
+            config.address = addr if addr
+            config.token = token if token
             config.ssl_pem_file = @config[:ssl_pem_file] if @config[:ssl_pem_file]
             config.ssl_verify = @config[:ssl_verify] if @config[:ssl_verify]
             config.ssl_ca_cert = @config[:ssl_ca_cert] if config.respond_to? :ssl_ca_cert


### PR DESCRIPTION
This enables the configuration of ruby-vault via environment variables
even if settings are available via the yaml file.

Usage:

``` yaml
:vault:
  :prioritize_env: true # default is false
```

This will take eg. `VAULT_TOKEN` from environment over `:token:` in
hiera.yaml if both are set.

This fixes issue #23
