### PR TITLE
Fixed a config bug

### DIFF
--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -28,10 +28,10 @@ class Hiera
         begin
           @vault = Vault::Client.new
           @vault.configure do |config|
-            config.address = @config[:addr] if @config[:addr]
-            config.token = @config[:token] if @config[:token]
-            config.ssl_pem_file = @config[:ssl_pem_file] if @config[:ssl_pem_file]
-            config.ssl_verify = @config[:ssl_verify] if @config[:ssl_verify]
+            config.address = @config[:addr] unless @config[:addr].nil?
+            config.token = @config[:token] unless @config[:token].nil?
+            config.ssl_pem_file = @config[:ssl_pem_file] unless @config[:ssl_pem_file].nil?
+            config.ssl_verify = @config[:ssl_verify] unless @config[:ssl_verify].nil?
             config.ssl_ca_cert = @config[:ssl_ca_cert] if config.respond_to? :ssl_ca_cert
             config.ssl_ca_path = @config[:ssl_ca_path] if config.respond_to? :ssl_ca_path
             config.ssl_ciphers = @config[:ssl_ciphers] if config.respond_to? :ssl_ciphers


### PR DESCRIPTION
Fixed an interesting bug.  The following line does not do what many would expect:

  config.ssl_verify = @config[:ssl_verify] if @config[:ssl_verify]

The original intent of that line was to set the config.ssl_verify variable to the value of @config[:ssl_verify] if it was set.  However, if you set @config[:ssl_verify] to false, then it woun't actually set the value of config.ssl_verify because the if failed (and the default value for config.ssl_verify is true).  I changed the "if <blah>" to "unless <blah>.nil?".  I also changed the other config tests that probably would never be "false", but just in case.  :)