### PR TITLE
Add support for the approle authentication backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ via the same environment variables read by
 
     VAULT_TOKEN=secret hiera -c hiera.yml foo
 
+To authenticate using the AppRole backend provide the `:role_id` parameter:
+
+    :backends:
+        - vault
+
+    :vault:
+        :addr: http://127.0.0.1:8200
+        :role_id: id_here
+
+And create a file `/var/lib/vault/secret_id` on the host where hiera will be used
+with the `secret_id`. This path can be customized using the `:secret_id_path`
+configuration option.
+
 
 ## Lookups
 

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -29,7 +29,19 @@ class Hiera
           @vault = Vault::Client.new
           @vault.configure do |config|
             config.address = @config[:addr] unless @config[:addr].nil?
-            config.token = @config[:token] unless @config[:token].nil?
+            if @config[:token].nil? # if no token provided use the approle method to authenticate
+              # read the secert from disk since storing it in hiera is equally
+              # secure as storing the token in hiera
+              if @config[:secret_id_path].nil?
+                secret_id_path = "/var/lib/vault/secret_id" # default path
+              else
+                secret_id_path = @config[:secret_id_path]
+              end
+              secret_id = File.read(secret_id_path)
+              @vault.auth.approle(@config[:role_id], secret_id)
+            else
+              config.token = @config[:token] unless @config[:token].nil?
+            end
             config.ssl_pem_file = @config[:ssl_pem_file] unless @config[:ssl_pem_file].nil?
             config.ssl_verify = @config[:ssl_verify] unless @config[:ssl_verify].nil?
             config.ssl_ca_cert = @config[:ssl_ca_cert] if config.respond_to? :ssl_ca_cert


### PR DESCRIPTION
The approle authentication seems like the best solution for in a puppetized env: https://www.vaultproject.io/docs/auth/approle.html.

I prefer to store the secret_id on the host in a file and not in hiera, since this would be the same as storing the token directly.