### PR TITLE
Support specific vault hiearchy to prevent long and slow lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,28 @@ will result in lookups through the following paths in vault:
     secret/...
     secret/common
 
+### Custom hierarchy
+
+When using a large hierarchy in hiera, the process for looking up all parameters
+can take long. To prevent this a vault specific hiearchy can be provided.
+
+```
+:backends:
+    - vault
+
+:hierarchy:
+  - "nodes/%{::fqdn}"
+  - "hostclass/%{::hostclass}"
+  - ...
+  - common
+
+:vault:
+    :addr: ...
+    :custom_hiearchy:
+      - "nodes/%{::fqdn}"
+      - common/common
+```
+
 
 ## SSL
 

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -35,6 +35,12 @@ class Hiera
             config.ssl_ca_cert = @config[:ssl_ca_cert] if config.respond_to? :ssl_ca_cert
             config.ssl_ca_path = @config[:ssl_ca_path] if config.respond_to? :ssl_ca_path
             config.ssl_ciphers = @config[:ssl_ciphers] if config.respond_to? :ssl_ciphers
+            if @config[:custom_hiearchy].nil?
+              @custom_hiearchy = nil
+            else
+              @custom_hiearchy = @config[:custom_hiearchy]
+            end
+            Hiera.debug("[hiera-vault] Using custom_hiearchy #{@custom_hiearchy}")
           end
 
           fail if @vault.sys.seal_status.sealed?
@@ -56,7 +62,7 @@ class Hiera
         # Only generic mounts supported so far
         @config[:mounts][:generic].each do |mount|
           path = Backend.parse_string(mount, scope, { 'key' => key })
-          Backend.datasources(scope, order_override) do |source|
+          Backend.datasources(scope, order_override, @custom_hiearchy) do |source|
             Hiera.debug("Looking in path #{path}/#{source}/")
             new_answer = lookup_generic("#{path}/#{source}/#{key}", scope)
             #Hiera.debug("[hiera-vault] Answer: #{new_answer}:#{new_answer.class}")

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -35,12 +35,12 @@ class Hiera
             config.ssl_ca_cert = @config[:ssl_ca_cert] if config.respond_to? :ssl_ca_cert
             config.ssl_ca_path = @config[:ssl_ca_path] if config.respond_to? :ssl_ca_path
             config.ssl_ciphers = @config[:ssl_ciphers] if config.respond_to? :ssl_ciphers
-            if @config[:custom_hiearchy].nil?
-              @custom_hiearchy = nil
+            if @config[:custom_hierarchy].nil?
+              @custom_hierarchy = nil
             else
-              @custom_hiearchy = @config[:custom_hiearchy]
+              @custom_hierarchy = @config[:custom_hierarchy]
             end
-            Hiera.debug("[hiera-vault] Using custom_hiearchy #{@custom_hiearchy}")
+            Hiera.debug("[hiera-vault] Using custom_hierarchy #{@custom_hierarchy}")
           end
 
           fail if @vault.sys.seal_status.sealed?
@@ -62,7 +62,7 @@ class Hiera
         # Only generic mounts supported so far
         @config[:mounts][:generic].each do |mount|
           path = Backend.parse_string(mount, scope, { 'key' => key })
-          Backend.datasources(scope, order_override, @custom_hiearchy) do |source|
+          Backend.datasources(scope, order_override, @custom_hierarchy) do |source|
             Hiera.debug("Looking in path #{path}/#{source}/")
             new_answer = lookup_generic("#{path}/#{source}/#{key}", scope)
             #Hiera.debug("[hiera-vault] Answer: #{new_answer}:#{new_answer.class}")


### PR DESCRIPTION
In our situation we have a large hiearchy in hiera (20+) and every parameter will be searched in these 20 paths, but we only use 1-3 hiearchies in vault, therefore I introduced the custom_hiearchy paramter to this backend.