### PR TITLE
Feature/vault filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ In case the single field does not contain a parseable JSON string, the string wi
 When used in Hash lookups, this will result in an error as normal.
 
 
+#### Vault Filter - optional
+Only applicable when `:vault_filter` is used.
+To use Vault Filter, set, for example:
+
+    :vault:
+        :vault_filter: vault
+
+This will result on only keys starting with the key `vault` being looked up against vault, all other lookups will skip the vault backend.
+
+
 ### Lookup type behavior
 
 In case Array or Hash lookup is done, usual array or hash merging takes place based on the configured global `:merge_behavior` setting.

--- a/README.md
+++ b/README.md
@@ -102,14 +102,19 @@ In case the single field does not contain a parseable JSON string, the string wi
 When used in Hash lookups, this will result in an error as normal.
 
 
-#### Vault Filter - optional
-Only applicable when `:vault_filter` is used.
-To use Vault Filter, set, for example:
+#### Filter Prefix - optional
+Only applicable when `:filter_prefix` is used.
+To use Filter by prefix, set, for example:
 
     :vault:
-        :vault_filter: vault
+        :filter_prefix: 'vault::'
+        :filter_mode: 0
 
-This will result on only keys starting with the key `vault` being looked up against vault, all other lookups will skip the vault backend.
+This will cause only keys prefixed with `vault::` to be looked up against vault, all other keys will skip the vault backend.
+
+`filter_mode` option `1` will remove your given `filter_prefix` from the key prior to the look up against the vault backend, this
+could be useful in some cases to avoid rewriting keys in vault to meet the requirements of your filter, if unset or set to `0` the exact 
+key name used in the hiera function will be used in the vault lookup.
 
 
 ### Lookup type behavior

--- a/hiera-vault.gemspec
+++ b/hiera-vault.gemspec
@@ -3,7 +3,7 @@ require 'rubygems/package_task'
 
 spec = Gem::Specification.new do |gem|
     gem.name = "hiera-vault"
-    gem.version = "0.2.2"
+    gem.version = "0.2.2.1"
     gem.license = "Apache-2.0"
     gem.summary = "Module for using vault as a hiera backend"
     gem.email = "jonathan.sokolowski@gmail.com"

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -52,8 +52,10 @@ class Hiera
 
       def lookup(key, scope, order_override, resolution_type)
         return nil if @vault.nil?
-        filter = @config[:vault_filter]
-        return nil if not (key[/^#{filter}/])
+        if not @config[:vault_filter].nil?
+          filter = @config[:vault_filter]
+          return nil if not (key[/^#{filter}/])
+        end
 
         Hiera.debug("[hiera-vault] Looking up #{key} in vault backend")
 

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -35,6 +35,11 @@ class Hiera
             config.ssl_ca_cert = @config[:ssl_ca_cert] if config.respond_to? :ssl_ca_cert
             config.ssl_ca_path = @config[:ssl_ca_path] if config.respond_to? :ssl_ca_path
             config.ssl_ciphers = @config[:ssl_ciphers] if config.respond_to? :ssl_ciphers
+            if @config[:vault_filter].nil?
+              @vault_filter = nil
+            else
+              @vault_filter = @config[:vault_filter]
+            end
           end
 
           fail if @vault.sys.seal_status.sealed?
@@ -47,6 +52,8 @@ class Hiera
 
       def lookup(key, scope, order_override, resolution_type)
         return nil if @vault.nil?
+        filter = @config[:vault_filter]
+        return nil if not (key[/^#{filter}/])
 
         Hiera.debug("[hiera-vault] Looking up #{key} in vault backend")
 

--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -35,10 +35,15 @@ class Hiera
             config.ssl_ca_cert = @config[:ssl_ca_cert] if config.respond_to? :ssl_ca_cert
             config.ssl_ca_path = @config[:ssl_ca_path] if config.respond_to? :ssl_ca_path
             config.ssl_ciphers = @config[:ssl_ciphers] if config.respond_to? :ssl_ciphers
-            if @config[:vault_filter].nil?
-              @vault_filter = nil
+            if @config[:filter_prefix].nil?
+              @filter_prefix = nil
             else
-              @vault_filter = @config[:vault_filter]
+              @filter_prefix = @config[:filter_prefix]
+            end
+            if @config[:filter_mode].nil?
+              @filter_mode = 0
+            else
+              @filter_mode = @config[:filter_mode]
             end
           end
 
@@ -52,9 +57,12 @@ class Hiera
 
       def lookup(key, scope, order_override, resolution_type)
         return nil if @vault.nil?
-        if not @config[:vault_filter].nil?
-          filter = @config[:vault_filter]
+        if not @config[:filter_prefix].nil?
+          filter = @config[:filter_prefix]
           return nil if not (key[/^#{filter}/])
+          if @config[:filter_mode] > 0
+            key = key.sub(/^#{filter}/, '')
+          end
         end
 
         Hiera.debug("[hiera-vault] Looking up #{key} in vault backend")


### PR DESCRIPTION
* Adds the ability to limit requests make to the vault backend based on a key prefix. 
* filter mode allows the given filter prefix to be stripped from the key prior to vault lookup.

The driver behind this change in my case was the volume of requests coming from class parameter lookups during each catalog compilation was slowing my puppet runs down and in some cases causing catalogs to fail to compile due to errors querying vault. 

In my case I am using vault for only a limited sub set of secrets so exposing all hiera lookups to the vault wasn't necessary.