### PR TITLE
Fix translation issue with version 5 hiera.yaml

### DIFF
--- a/lib/hiera/backend/vault_backend.rb
+++ b/lib/hiera/backend/vault_backend.rb
@@ -9,7 +9,7 @@ class Hiera
 
         @config = Config[:vault]
         @config[:mounts] ||= {}
-        @config[:mounts][:generic] ||= ['secret']
+        @config[:mounts][:generic] ||= @config[:mounts]['generic'] || ['secret']
         @config[:default_field_parse] ||= 'string' # valid values: 'string', 'json'
 
         if not ['string','json'].include?(@config[:default_field_parse])


### PR DESCRIPTION
With the version 5 `hiera.yaml` format, we can still use older custom backends like this via `hiera3_backend`. There appears to be some magic to translate hash keys from `name` to `:name` for compatibility purposes, but it doesn't appear to recurse down into options more than one level deep, resulting in a mounts hash that looks like `"generic"=>"foo"}` instead of `:mounts=>{:generic=>"puppet"}`. This is a quick hack to just work around the problem, in lieu of a proper conversion to version 5.